### PR TITLE
Add plan selection for BuyPlus

### DIFF
--- a/src/routes/[lang]/portal/BuyPlus.svelte
+++ b/src/routes/[lang]/portal/BuyPlus.svelte
@@ -30,9 +30,10 @@
 		paymentBackends.set('wxpay', wxpayBackend());
 	}
 
-	let days = 30;
-	let promo = '';
-	let item: 'plus' | 'giftcard' = variant === 'reseller' ? 'giftcard' : 'plus';
+        let days = 30;
+        let promo = '';
+        let item: 'plus' | 'giftcard' = variant === 'reseller' ? 'giftcard' : 'plus';
+        let plan: 'basic' | 'unlimited' = 'unlimited';
 
 	let recipientEmail = '';
 	let sender = variant === 'reseller' ? 'Reseller' : '';
@@ -46,27 +47,35 @@
 			.join('&');
 	};
 
-	const makeItem = (item: 'plus' | 'giftcard', email: string, sender: string, count: number) => {
-		var enum_item: Item = 'Plus';
-		if (item == 'giftcard') {
-			enum_item = {
-				Giftcard: { recipient_email: email, sender: sender, count: count }
-			};
-		}
-		return enum_item;
-	};
+        const makeItem = (
+                item: 'plus' | 'giftcard',
+                email: string,
+                sender: string,
+                count: number
+        ) => {
+                let enum_item: Item;
+                if (item == 'giftcard') {
+                        enum_item = {
+                                Giftcard: { recipient_email: email, sender: sender, count: count }
+                        };
+                } else {
+                        enum_item = plan === 'basic' ? 'Basic' : 'Plus';
+                }
+                return enum_item;
+        };
 
 	let cost: number | null = null;
-	const recalcCost = debounce(async (obj: any) => {
-		for (;;) {
-			try {
-				cost = null;
-				const response = await call_rpc('calculate_price', [
-					obj['sessid'],
-					obj['method'],
-					obj['promo'],
-					obj['days']
-				]);
+        const recalcCost = debounce(async (obj: any) => {
+                for (;;) {
+                        try {
+                                cost = null;
+                                const rpc = plan === 'basic' ? 'calculate_basic_price' : 'calculate_price';
+                                const response = await call_rpc(rpc, [
+                                        obj['sessid'],
+                                        obj['method'],
+                                        obj['promo'],
+                                        obj['days']
+                                ]);
 				cost = response / 100;
 				return;
 			} catch (e) {
@@ -74,12 +83,13 @@
 			}
 		}
 	}, 100);
-	$: recalcCost({
-		sessid: sessionStorage.getItem('sessid'),
-		promo: item === 'giftcard' && variant != 'reseller' ? '' : promo,
-		days: item === 'giftcard' ? days * giftcards_number : days,
-		method: payMethod
-	});
+        $: recalcCost({
+                sessid: sessionStorage.getItem('sessid'),
+                promo: item === 'giftcard' && variant != 'reseller' ? '' : promo,
+                days: item === 'giftcard' ? days * giftcards_number : days,
+                method: payMethod,
+                plan
+        });
 
 	const change_days = () => {
 		days = Math.floor(
@@ -154,8 +164,35 @@
 				</div>
 			</div>
 		</div>
-	{/if}
-	{#if item == 'giftcard'}
+        {/if}
+        {#if item != 'giftcard'}
+                <div class="row mt-3">
+                        <div class="col">
+                                <h2>{to_local('what-plan-buying')}</h2>
+                                <div class="d-flex">
+                                        <button
+                                                class="btn btn-outline-dark me-2"
+                                                on:click={() => {
+                                                        plan = 'basic';
+                                                }}
+                                                class:selected={plan === 'basic'}
+                                        >
+                                                {to_local('basic')}
+                                        </button>
+                                        <button
+                                                class="btn btn-outline-dark"
+                                                on:click={() => {
+                                                        plan = 'unlimited';
+                                                }}
+                                                class:selected={plan === 'unlimited'}
+                                        >
+                                                {to_local('unlimited')}
+                                        </button>
+                                </div>
+                        </div>
+                </div>
+        {/if}
+        {#if item == 'giftcard'}
 		<div class="row mt-3">
 			{#if variant !== 'reseller'}
 				<div class="col-lg">

--- a/src/routes/[lang]/portal/billing.ts
+++ b/src/routes/[lang]/portal/billing.ts
@@ -1,123 +1,133 @@
-import axios from "axios";
-import { BINDER_ADDR, call_rpc } from "../../helpers";
-import { goto } from "$app/navigation";
+import axios from 'axios';
+import { BINDER_ADDR, call_rpc } from '../../helpers';
+import { goto } from '$app/navigation';
 import { localize } from '../../l10n';
 
-
-export type Item = "Plus" | {
-  "Giftcard": { recipient_email: string, sender: string, count: number }
-}
+export type Item =
+        | 'Plus'
+        | 'Basic'
+        | {
+                        Giftcard: { recipient_email: string; sender: string; count: number };
+          };
 
 export interface PaymentBackend {
-  name: string,
-  icons: string[],
-  markup: number,
-  pay: (arg0: number, arg1: string, arg2: Item, is_subscription: boolean) => Promise<void>
+	name: string;
+	icons: string[];
+	markup: number;
+	pay: (arg0: number, arg1: string, arg2: Item, is_subscription: boolean) => Promise<void>;
 }
 
 export function stripeCardBackend(): PaymentBackend {
-  return stripeBackendReal("bank-card", ["card", "paypal"])
+	return stripeBackendReal('bank-card', ['card', 'paypal']);
 }
 
 export function stripePaypalBackend(): PaymentBackend {
-  return stripeBackendReal("paypal", ["paypal"])
+	return stripeBackendReal('paypal', ['paypal']);
 }
 
 function stripeBackendReal(name: string, payment_methods: string[]): PaymentBackend {
-  const STRIPEKEY = "pk_live_Wk781YzANKGuLBl2NzFkRu5n00YdYjObFY";
-  // const STRIPEKEY = "pk_test_O6w7losqr4Z0LrJvvhotXgBO00kog9HPMC";
-  return {
-    name,
-    icons: name == 'paypal' ? ['/paypal.svg', "/unionpay.svg"] : ["/visa.jpg", "/mastercard.svg"],
-    markup: 0,
-    pay: async (days: number, promo: string, item: Item, is_recurring: boolean) => {
-      is_recurring = name != 'paypal' && is_recurring;
-      const sid = await call_rpc("start_stripe", [sessionStorage.getItem("sessid") || "RESELLER", { promo, days, item, is_recurring }])
-      console.log(sid);
-      const stripe = ((window as any)["Stripe"] as any)(STRIPEKEY);
-      const { error } = await stripe.redirectToCheckout({
-        sessionId: sid,
-      });
-      if (error) {
-        alert(error);
-      }
-    },
-  }
+	const STRIPEKEY = 'pk_live_Wk781YzANKGuLBl2NzFkRu5n00YdYjObFY';
+	// const STRIPEKEY = "pk_test_O6w7losqr4Z0LrJvvhotXgBO00kog9HPMC";
+	return {
+		name,
+		icons: name == 'paypal' ? ['/paypal.svg', '/unionpay.svg'] : ['/visa.jpg', '/mastercard.svg'],
+		markup: 0,
+		pay: async (days: number, promo: string, item: Item, is_recurring: boolean) => {
+			is_recurring = name != 'paypal' && is_recurring;
+			const sid = await call_rpc('start_stripe', [
+				sessionStorage.getItem('sessid') || 'RESELLER',
+				{ promo, days, item, is_recurring }
+			]);
+			console.log(sid);
+			const stripe = ((window as any)['Stripe'] as any)(STRIPEKEY);
+			const { error } = await stripe.redirectToCheckout({
+				sessionId: sid
+			});
+			if (error) {
+				alert(error);
+			}
+		}
+	};
 }
 
 export function alipayBackend(): PaymentBackend {
-  return {
-    name: 'alipay',
-    icons: ["/alipay.svg"],
-    markup: 8,
-    pay: async (days: number, promo: string, item: Item) => {
-      let url = await call_rpc("start_aliwechat", [sessionStorage.getItem("sessid") || "RESELLER", {
-        promo,
-        days,
-        method: 'alipay',
-        item
-      }]);
-      goto(url);
-    }
-  }
+	return {
+		name: 'alipay',
+		icons: ['/alipay.svg'],
+		markup: 8,
+		pay: async (days: number, promo: string, item: Item) => {
+			let url = await call_rpc('start_aliwechat', [
+				sessionStorage.getItem('sessid') || 'RESELLER',
+				{
+					promo,
+					days,
+					method: 'alipay',
+					item
+				}
+			]);
+			goto(url);
+		}
+	};
 }
 
 export function wxpayBackend(): PaymentBackend {
-  return {
-    name: 'wxpay',
-    icons: ["/wxpay.png"],
-    markup: 8,
-    pay: async (days: number, promo: string, item: Item) => {
-      let url = await call_rpc("start_aliwechat", [sessionStorage.getItem("sessid") || "RESELLER", {
-        promo,
-        days,
-        method: 'wxpay',
-        item,
-        mobile: await isMobile()
-      }]);
-      goto(url);
-    }
-  }
+	return {
+		name: 'wxpay',
+		icons: ['/wxpay.png'],
+		markup: 8,
+		pay: async (days: number, promo: string, item: Item) => {
+			let url = await call_rpc('start_aliwechat', [
+				sessionStorage.getItem('sessid') || 'RESELLER',
+				{
+					promo,
+					days,
+					method: 'wxpay',
+					item,
+					mobile: await isMobile()
+				}
+			]);
+			goto(url);
+		}
+	};
 }
 
 async function isMobile() {
-  // 1. Check if User-Agent Client Hints are supported
-  if (navigator.userAgentData && 'getHighEntropyValues' in navigator.userAgentData) {
-    try {
-      // getHighEntropyValues returns a promise with more detailed info
-      const uaData = await navigator.userAgentData.getHighEntropyValues(['mobile']);
-      return uaData.mobile;
-    } catch (error) {
-      // if there's any error, fallback to user agent string
-      console.error(error);
-      return fallbackIsMobile();
-    }
-  } else {
-    // 2. Fallback to user agent string detection
-    const isMobile = fallbackIsMobile();
-    console.log(isMobile);
-    return isMobile;
-  }
+	// 1. Check if User-Agent Client Hints are supported
+	if (navigator.userAgentData && 'getHighEntropyValues' in navigator.userAgentData) {
+		try {
+			// getHighEntropyValues returns a promise with more detailed info
+			const uaData = await navigator.userAgentData.getHighEntropyValues(['mobile']);
+			return uaData.mobile;
+		} catch (error) {
+			// if there's any error, fallback to user agent string
+			console.error(error);
+			return fallbackIsMobile();
+		}
+	} else {
+		// 2. Fallback to user agent string detection
+		const isMobile = fallbackIsMobile();
+		console.log(isMobile);
+		return isMobile;
+	}
 }
 
 function fallbackIsMobile() {
-  console.log("fallback!")
-  // Common approach: simple regex for known mobile user agents
-  return /Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+	console.log('fallback!');
+	// Common approach: simple regex for known mobile user agents
+	return /Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 }
 
-
 export function cryptoBackend(): PaymentBackend {
-  return {
-    name: 'crypto',
-    icons: ["/bitcoin.png"],
-    markup: 0,
-    pay: async (days: number, promo: string, item: Item) => {
-      sessionStorage.setItem("days", days.toString());
-      sessionStorage.setItem("promo", promo);
-      sessionStorage.setItem("item", JSON.stringify(item));
+	return {
+		name: 'crypto',
+		icons: ['/bitcoin.png'],
+		markup: 0,
+		pay: async (days: number, promo: string, item: Item) => {
+			sessionStorage.setItem('days', days.toString());
+			sessionStorage.setItem('promo', promo);
+			sessionStorage.setItem('item', JSON.stringify(item));
 
-      goto("./portal/pay_crypto");
-    }
-  }
+			goto('./portal/pay_crypto');
+		}
+	};
 }

--- a/src/routes/l10n_data.yaml
+++ b/src/routes/l10n_data.yaml
@@ -258,6 +258,18 @@ unlimited:
   zht: 無限版
   fa: نامحدود
 
+beta:
+  en: BETA
+  zhs: BETA
+  zht: BETA
+  fa: BETA
+
+basic-beta-blurb:
+  en: Basic plan limited to 5 GB per month
+  zhs: 基础版每月限量 5 GB
+  zht: 基礎版每月限量 5 GB
+  fa: طرح پایه هر ماه به ۵ گیگابایت محدود است
+
 sender:
   en: Sender
   zhs: 发送者

--- a/src/routes/l10n_data.yaml
+++ b/src/routes/l10n_data.yaml
@@ -65,10 +65,10 @@ geph:
   fa: Geph
 
 hero:
-  en: "The world&rsquo;s <b>most resilient</b> VPN"
-  zhs: "不怕封锁的 VPN"
-  zht: "不怕封鎖的 VPN"
-  fa: "وی‌پی‌ان متوقف‌نشدنی"
+  en: 'The world&rsquo;s <b>most resilient</b> VPN'
+  zhs: '不怕封锁的 VPN'
+  zht: '不怕封鎖的 VPN'
+  fa: 'وی‌پی‌ان متوقف‌نشدنی'
 
 sub_hero:
   en: >-
@@ -193,10 +193,10 @@ error:
   fa: خطا
 
 remaining-days:
-  en: "Remaining days:"
-  zhs: "剩余天数："
-  zht: "剩餘天數："
-  fa: ": روزهای باقی مانده"
+  en: 'Remaining days:'
+  zhs: '剩余天数：'
+  zht: '剩餘天數：'
+  fa: ': روزهای باقی مانده'
 
 buy-plus:
   en: Buy Plus
@@ -239,6 +239,24 @@ someone-else:
   zhs: 其他人
   zht: 其他人
   fa: کسی دیگر
+
+what-plan-buying:
+  en: What plan are you buying?
+  zhs: 您购买哪个套餐？
+  zht: 您購買哪個套餐？
+  fa: کدام طرح را می‌خواهید بخرید؟
+
+basic:
+  en: Basic
+  zhs: 基础版
+  zht: 基礎版
+  fa: پایه
+
+unlimited:
+  en: Unlimited
+  zhs: 无限版
+  zht: 無限版
+  fa: نامحدود
 
 sender:
   en: Sender
@@ -313,10 +331,10 @@ wxpay:
   fa: WeChat Pay
 
 total:
-  en: "Total:"
+  en: 'Total:'
   zhs: 总计：
   zht: 總計：
-  fa: "هزینه کل:"
+  fa: 'هزینه کل:'
 
 pay:
   en: Check out
@@ -487,10 +505,10 @@ incorrect-giftcard:
   fa: کارت هدیه‌ای یافت نشد
 
 giftcard-days:
-  en: "Days in giftcard: "
-  zhs: "礼品卡有效天数："
-  zht: "禮品卡有效天數："
-  fa: "روزها در کارت هدیه: "
+  en: 'Days in giftcard: '
+  zhs: '礼品卡有效天数：'
+  zht: '禮品卡有效天數：'
+  fa: 'روزها در کارت هدیه: '
 
 giftcard-applied:
   en: Giftcard applied
@@ -511,10 +529,10 @@ send-crypto:
   fa: ارسال ارز دیجیتال
 
 please-send-funds:
-  en: "Send cryptocurrency to the following address"
-  zhs: "请将加密货币发送至以下地址"
-  zht: "請將加密貨幣發送至以下地址"
-  fa: "ارز دیجیتال را به آدرس زیر بفرستید"
+  en: 'Send cryptocurrency to the following address'
+  zhs: '请将加密货币发送至以下地址'
+  zht: '請將加密貨幣發送至以下地址'
+  fa: 'ارز دیجیتال را به آدرس زیر بفرستید'
 
 amount:
   en: Amount


### PR DESCRIPTION
## Summary
- support Basic plan in billing
- let users choose Basic vs Unlimited plan
- send correct RPC for Basic pricing
- add translations for new UI strings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6851fa9031b48333bdaa41f6fed93b5b